### PR TITLE
Implement List Type Toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Configurable tools for working with markdown files in Neovim.
   - Insert new items
   - Auto-number ordered lists
   - Toggle task list items (GFM)
+  - Toggle between list types
 - Links
   - Add links over vim motions / visual selection
   - Follow links under the cursor
@@ -368,6 +369,16 @@ Most list editing commands are intended to be invoked by custom keymaps (see not
 - #### Toggle tasks
 
   The `:MDTaskToggle` command toggles the task(s) on the current cursor line (normal mode) or under the current visual selection (visual mode).
+
+- #### Toggle list types
+
+  The `:MDToggleListType [list_type]` command allows you to switch between ordered, unordered, and task list types at the current cursor position or within a selected range or for a list under cursor. The command accepts a single argument specifying the desired list type.
+
+  Examples:
+
+  - `:MDToggleListType ordered`: Toggle the current or selected list(s) to an ordered list.
+  - `:MDToggleListType unordered`: Toggle the current or selected list(s) to an unordered list.
+  - `:MDToggleListType task`: Toggle the current or selected list(s) to a task list.
 
 ### Links
 

--- a/doc/markdown.nvim.txt
+++ b/doc/markdown.nvim.txt
@@ -20,6 +20,7 @@ CONTENTS                                              *markdown.nvim.contents*
             Insert Items ....................... |markdown.lists.insert_item|
             Reset Numbering ................ |markdown.lists.reset_numbering|
             Toggle Tasks ....................... |markdown.lists.toggle_task|
+            Toggle List Type .............. |markdown.lists.toggle_list_type|
         Links .............................................. |markdown.links|
             Add ........................................ |markdown.links.add|
             Follow .................................. |markdown.links.follow|
@@ -264,6 +265,23 @@ TOGGLE TASKS                                      *markdown.lists.toggle_task*
                                                                *:MDTaskToggle*
 :MDTaskToggle           Toggles the task(s) on the current cursor line (normal
                         mode) or under selected lines (visual mode).
+
+TOGGLE LIST TYPE                             *markdown.lists.toggle_list_type*
+
+                                                           *:MDToggleListType*
+:MDToggleListType [list_type]  Dynamically switch between different list
+types (ordered, unordered, task) at the cursor's location or within a
+selected range. This command accepts a single argument specifying the 
+desired list type.
+
+Available list types include "ordered", "unordered", and "task".
+
+Examples:
+
+    :MDToggleListType ordered    Toggle the current or selected list(s) to an
+    ordered format.
+    :MDToggleListType task       Toggle the current or selected list(s) to a
+    task list.
 
 --------------------------------------------------------------------------------
 LINKS                                                         *markdown.links*

--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -211,6 +211,19 @@ local function setup_usr_cmds(bufnr)
 			force = true,
 			range = true,
 		})
+	create_cached_buf_usr_cmd(bufnr, "MDToggleListType", function(opts)
+		local args = vim.split(opts.args, " ", { trimempty = true })
+		local list_type = args[1] or "unordered"
+		list.toggle_list_type_at_cursor(list_type)
+	end, {
+		force = true,
+		nargs = 1,
+		-- autocompletion
+		complete = function()
+			return { "ordered", "unordered", "task" }
+		end,
+	})
+
 end
 
 local function setup_usr_keymaps(cfg, bufnr)


### PR DESCRIPTION
I added the `toggle_list_type` function that allows users to dynamically toggle between ordered, unordered, and task list types within Neovim

I haven't managed to start tests, so I haven't written any. But I didn't touch any existing code, only added a new one.

P.S. I liked your plugin, and I wanted to add some functionality that I would personally like to use. It is my first pull request to public repos, so I probably would need to fix something