### PR TITLE
Fix issue with link following in vim.fn.system.

### DIFF
--- a/lua/markdown/link.lua
+++ b/lua/markdown/link.lua
@@ -195,9 +195,9 @@ local function try_open(dest, sys)
 	if sys == "Windows_NT" then
 		vim.fn.system({ "explorer.exe", dest })
 	elseif sys == "Linux" then
-		vim.fn.system("xdg-open", dest)
+		vim.fn.system({ "xdg-open", dest })
 	elseif sys == "Darwin" then
-		vim.fn.system("open", dest)
+		vim.fn.system({ "open", dest })
 	else
 		return false
 	end


### PR DESCRIPTION
This will fix #8 for link following from macOS and Linux.

I'm not able to test the `xdg-open` branch, but I presume this will suffice. Can you check?