### PR TITLE
fix(link): switch from vim.fn.system() to vim.system()

### DIFF
--- a/lua/markdown/link.lua
+++ b/lua/markdown/link.lua
@@ -193,11 +193,11 @@ end
 ---@return boolean
 local function try_open(dest, sys)
 	if sys == "Windows_NT" then
-		vim.fn.system({ "explorer.exe", dest })
+		vim.system({ "explorer.exe", dest })
 	elseif sys == "Linux" then
-		vim.fn.system({ "xdg-open", dest })
+		vim.system({ "xdg-open", dest })
 	elseif sys == "Darwin" then
-		vim.fn.system({ "open", dest })
+		vim.system({ "open", dest })
 	else
 		return false
 	end


### PR DESCRIPTION
Thanks for the nice plugin.
This pull request switches the `vim.fn.system()` calls to the lua version `vim.system()` when opening files in the default application. According to the neovim docs this function is preferred from lua (see `:h system()`). 
The practical advantage (and motivation) for this change is that `vim.system()` runs asynchronously and does not block neovim while the external file is opened.

Warning: I only tested this under nightly and Linux.