### PR TITLE
if linked file does not exist, edit it anyway

### DIFF
--- a/lua/markdown/link.lua
+++ b/lua/markdown/link.lua
@@ -259,7 +259,8 @@ local function open_path(path, opts)
 			end
 		end
 	else
-		notify.info("path not found")
+		vim.cmd.edit(path)
+		notify.info("file " .. path .. " created")
 	end
 end
 


### PR DESCRIPTION
As the title says, when following a link, start editing the target file even if it does not exist. This allows to easily create new wiki pages for example.