### PR TITLE
fix(config)!: conditionally register nvim-treesitter module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
 
   tests:
     strategy:
+      fail-fast: false
       matrix:
-        version: [v0.9.5, stable]
+        version: [v0.9.5, v0.10.4, stable]
     uses: ./.github/workflows/tests.yml
     with:
       version: ${{ matrix.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,16 +10,31 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ inputs.version }}
-      - name: Run tests
+
+      - name: Install tree-sitter-cli
+        if: ${{ contains(fromJSON('["stable", "nightly"]'), inputs.version) }}
+        uses: tree-sitter/setup-action@v2
+        with:
+          install-lib: false
+
+      - name: Run tests (main)
+        if: ${{ contains(fromJSON('["stable", "nightly"]'), inputs.version) }}
         run: |
           nvim --headless -u ./tests/init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.lua'}"
+
+      # nvim-treesitter 'master' branch supports nvim v0.10.x-v0.12.x
+      - name: Run tests (legacy)
+        run: |
+          nvim --headless -u ./tests/init_legacy.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init_legacy.lua'}"

--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ Markdown buffers can be navigated with the following keymaps:
 <details>
 <summary><strong>markdown.nvim</strong> can also be configured as an <a href="https://github.com/nvim-treesitter/nvim-treesitter/">nvim-treesitter</a> module.</summary>
 
+>[!CAUTION]
+> This feature is only supported when using **nvim-treesitter**'s [`master` branch](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/README.md), which has been locked and remains available for backward compatibility.
+
 ### Module installation <!-- toc omit heading -->
 
 The following code snippets show how to install **markdown.nvim** as an **nvim-treesitter** module. Refer to [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/) for the appropriate way to install and manage parsers.

--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -2,122 +2,6 @@ local api = vim.api
 
 local M = {}
 
-local function set_keymaps()
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_toggle_emphasis)",
-		function()
-			return require("markdown.opfunc")("markdown.inline", "toggle_emphasis")
-		end,
-		{
-			expr = true,
-			silent = true,
-			desc = "Toggle emphasis around a motion",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_toggle_emphasis_line)",
-		function()
-			return "^" .. tostring(vim.v.count1) .. "<Plug>(markdown_toggle_emphasis)g_"
-		end,
-		{
-			expr = true,
-			silent = true,
-			desc = "Toggle emphasis around a line",
-		})
-	vim.keymap.set(
-		"x",
-		"<Plug>(markdown_toggle_emphasis_visual)",
-		"<Esc>gv<Cmd>lua require'markdown.inline'.toggle_emphasis_visual()<CR>",
-		{
-			silent = true,
-			desc = "Toggle emphasis around a visual selection",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_delete_emphasis)",
-		"<Cmd>lua require'markdown.inline'.delete_surrounding_emphasis()<CR>",
-		{
-			silent = true,
-			desc = "Delete emphasis around the cursor",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_change_emphasis)",
-		"<Cmd>lua require'markdown.inline'.change_surrounding_emphasis()<CR>",
-		{
-			silent = true,
-			desc = "Change emphasis around the cursor",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_add_link)",
-		function()
-			return require("markdown.opfunc")("markdown.link", "add")
-		end,
-		{
-			expr = true,
-			silent = true,
-			desc = "Add link around a motion",
-		})
-	vim.keymap.set(
-		"x",
-		"<Plug>(markdown_add_link_visual)",
-		"<Esc>gv<Cmd>lua require'markdown.link'.add_visual()<CR>",
-		{
-			silent = true,
-			desc = "Add link around a visual selection",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_follow_link)",
-		"<Cmd>lua require'markdown.link'.follow()<CR>",
-		{
-			silent = true,
-			desc = "Follow link under the cursor",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_follow_link_default_app)",
-		"<Cmd>lua require'markdown.link'.follow({ use_default_app = true })<CR>",
-		{
-			silent = true,
-			desc = "Follow link under the cursor using default app for non-markdown files",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_go_current_heading)",
-		"<Cmd>lua require'markdown.nav'.curr_heading()<CR>",
-		{
-			silent = true,
-			desc = "Set cursor to current section heading",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_go_parent_heading)",
-		"<Cmd>lua require'markdown.nav'.parent_heading()<CR>",
-		{
-			silent = true,
-			desc = "Set cursor to parent section heading",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_go_next_heading)",
-		"<Cmd>lua require'markdown.nav'.next_heading()<CR>",
-		{
-			silent = true,
-			desc = "Set cursor to next section heading",
-		})
-	vim.keymap.set(
-		"n",
-		"<Plug>(markdown_go_prev_heading)",
-		"<Cmd>lua require'markdown.nav'.prev_heading()<CR>",
-		{
-			silent = true,
-			desc = "Set cursor to previous section heading",
-		})
-end
-
 ---@type table<integer, { cmds: table, maps: table }>
 local cache
 
@@ -376,14 +260,9 @@ function M.setup(cfg)
 	end
 end
 
---- Sets plugin keymaps and attempts to initialize plugin as treesitter module.
-function M.init()
-	set_keymaps()
-
-	local ok, nvim_ts = pcall(require, "nvim-treesitter")
-	if not ok then return end
-
-	nvim_ts.define_modules({
+--- Initializes the plugin as treesitter module.
+function M.define_nvim_ts_module()
+	require("nvim-treesitter").define_modules({
 		markdown = {
 			attach = function(bufnr, _)
 				if not check_deps() then
@@ -411,7 +290,7 @@ function M.init()
 			is_supported = function(lang)
 				return lang == "markdown"
 			end,
-		}
+		},
 	})
 end
 

--- a/plugin/markdown.lua
+++ b/plugin/markdown.lua
@@ -1,1 +1,131 @@
-require("markdown").init()
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_toggle_emphasis)",
+	function()
+		return require("markdown.opfunc")("markdown.inline", "toggle_emphasis")
+	end,
+	{
+		expr = true,
+		silent = true,
+		desc = "Toggle emphasis around a motion",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_toggle_emphasis_line)",
+	function()
+		return "^" .. tostring(vim.v.count1) .. "<Plug>(markdown_toggle_emphasis)g_"
+	end,
+	{
+		expr = true,
+		silent = true,
+		desc = "Toggle emphasis around a line",
+	}
+)
+vim.keymap.set(
+	"x",
+	"<Plug>(markdown_toggle_emphasis_visual)",
+	"<Esc>gv<Cmd>lua require'markdown.inline'.toggle_emphasis_visual()<CR>",
+	{
+		silent = true,
+		desc = "Toggle emphasis around a visual selection",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_delete_emphasis)",
+	"<Cmd>lua require'markdown.inline'.delete_surrounding_emphasis()<CR>",
+	{
+		silent = true,
+		desc = "Delete emphasis around the cursor",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_change_emphasis)",
+	"<Cmd>lua require'markdown.inline'.change_surrounding_emphasis()<CR>",
+	{
+		silent = true,
+		desc = "Change emphasis around the cursor",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_add_link)",
+	function()
+		return require("markdown.opfunc")("markdown.link", "add")
+	end,
+	{
+		expr = true,
+		silent = true,
+		desc = "Add link around a motion",
+	}
+)
+vim.keymap.set(
+	"x",
+	"<Plug>(markdown_add_link_visual)",
+	"<Esc>gv<Cmd>lua require'markdown.link'.add_visual()<CR>",
+	{
+		silent = true,
+		desc = "Add link around a visual selection",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_follow_link)",
+	"<Cmd>lua require'markdown.link'.follow()<CR>",
+	{
+		silent = true,
+		desc = "Follow link under the cursor",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_follow_link_default_app)",
+	"<Cmd>lua require'markdown.link'.follow({ use_default_app = true })<CR>",
+	{
+		silent = true,
+		desc = "Follow link under the cursor using default app for non-markdown files",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_go_current_heading)",
+	"<Cmd>lua require'markdown.nav'.curr_heading()<CR>",
+	{
+		silent = true,
+		desc = "Set cursor to current section heading",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_go_parent_heading)",
+	"<Cmd>lua require'markdown.nav'.parent_heading()<CR>",
+	{
+		silent = true,
+		desc = "Set cursor to parent section heading",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_go_next_heading)",
+	"<Cmd>lua require'markdown.nav'.next_heading()<CR>",
+	{
+		silent = true,
+		desc = "Set cursor to next section heading",
+	}
+)
+vim.keymap.set(
+	"n",
+	"<Plug>(markdown_go_prev_heading)",
+	"<Cmd>lua require'markdown.nav'.prev_heading()<CR>",
+	{
+		silent = true,
+		desc = "Set cursor to previous section heading",
+	}
+)
+
+local ok, nvim_ts = pcall(require, "nvim-treesitter")
+if ok and vim.is_callable(nvim_ts.define_modules) then
+	require("markdown").define_nvim_ts_module()
+end

--- a/tests/init_legacy.lua
+++ b/tests/init_legacy.lua
@@ -1,6 +1,6 @@
 local function root(path)
 	local f = debug.getinfo(1, "S").source:sub(2)
-	return vim.fn.fnamemodify(f, ":p:h:h") .. "/.tests/" .. (path or "")
+	return vim.fn.fnamemodify(f, ":p:h:h") .. "/.tests/legacy/" .. (path or "")
 end
 
 local function exists(path)
@@ -32,15 +32,13 @@ local function load(plugin, branch)
 	vim.cmd("packadd " .. name)
 end
 
-local site = root("site")
-
 vim.cmd([[set runtimepath=$VIMRUNTIME]])
 vim.opt.runtimepath:append(root())
-vim.opt.packpath = { site }
+vim.opt.packpath = { root("site") }
 
 load("nvim-lua/plenary.nvim")
-load("nvim-treesitter/nvim-treesitter", "main")
+load("nvim-treesitter/nvim-treesitter", "master")
 
-local nvim_ts = require("nvim-treesitter")
-nvim_ts.setup({ install_dir = site })
-nvim_ts.install({ "markdown", "markdown_inline" }, { summary = true }):wait(300000)
+if vim.api.nvim_get_commands({}).TSUpdateSync ~= nil then
+	vim.cmd("TSUpdateSync markdown markdown_inline")
+end

--- a/tests/scripts/run
+++ b/tests/scripts/run
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-nvim --headless -u ./tests/init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.lua'}"

--- a/tests/scripts/run.ps1
+++ b/tests/scripts/run.ps1
@@ -1,1 +1,2 @@
-& nvim --headless -u .\tests\init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.lua'}"
+(& nvim --headless -u .\tests\init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.lua'}") -and
+(& nvim --headless -u .\tests\init_legacy.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init_legacy.lua'}")

--- a/tests/scripts/run.sh
+++ b/tests/scripts/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+nvim --headless -u ./tests/init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.lua'}" &&
+	nvim --headless -u ./tests/init_legacy.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init_legacy.lua'}"


### PR DESCRIPTION
'nvim-treesitter' modules are a legacy feature that are only supported by the plugin's 'master' branch. This plugin now checks to see if the feature is supported by the installed 'nvim-treesitter' version before defining itself as a module. Support may be removed completely in the future.

Additionally, '<Plug>' keymaps are now registered without requiring a call to the main module's `init` function, improving startup time when targetting the 'nvim-treesitter' 'main' branch. The `init` function has been replaced with `define_nvim_ts_module`.

Closes #23.