### PR TITLE
Mark on jumplist before following header link

### DIFF
--- a/lua/markdown/link.lua
+++ b/lua/markdown/link.lua
@@ -176,6 +176,7 @@ local function follow_heading_link(dest, root)
 			_, text = M.get_heading_link(text)
 			if text == dest then
 				local row = heading:start()
+				vim.cmd.normal { "m'", bang = true }
 				api.nvim_win_set_cursor(0, { row + 1, 0 })
 				return
 			end


### PR DESCRIPTION
In the current behavior, following a link to a header in the same file does not add an entry to the jumplist, so trying to go back with `<C-o>` won't work. This change just sets the previous context mark, which adds the current position to the jumplist before jumping